### PR TITLE
Preserve markdown on JSON import

### DIFF
--- a/src/components/InputForm/ObjectForm.tsx
+++ b/src/components/InputForm/ObjectForm.tsx
@@ -117,9 +117,8 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
               ...prev.zflnJson,
               arguments: importedArgs
             },
-            metadata: nextMeta,
-            // Do not modify markdownContent when importing JSON
-            markdownContent: prev.markdownContent || ''
+            metadata: nextMeta
+            // markdownContent intentionally left unchanged
           }
         })
         log('applied initialData mapping', { argsLen: importedArgs.length, title: importedTitle })

--- a/src/components/InputForm/ObjectFormModal.tsx
+++ b/src/components/InputForm/ObjectFormModal.tsx
@@ -75,7 +75,12 @@ export default function ObjectFormModal({
       if (file) {
         try {
           const data = await readJsonFile(file)
-          const normalized = normalizeImportedJSON(data)
+          // Normalize and strip any markdownContent fields to avoid overwriting
+          // existing markdown in ObjectForm
+          const normalized = normalizeImportedJSON(data).map(arg => {
+            const { markdownContent, ...rest } = arg as any
+            return rest
+          })
           setImportedData(normalized)
           setFormProgress(75)
         } catch (error) {

--- a/src/tests/components/ObjectForm.test.tsx
+++ b/src/tests/components/ObjectForm.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import ObjectForm from '../../components/InputForm/ObjectForm'
+import { vi } from 'vitest'
 
 vi.mock('../../services/apiConfig', () => ({
   getCurrentAPI: () => ({
@@ -27,6 +28,57 @@ describe('ObjectForm', () => {
 
     // No throw; basic smoke
     expect(submit).toBeInTheDocument()
+  })
+
+  it('preserves markdown content when importing JSON', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={[{ pathname: '/create' }] as any}>
+        <ObjectForm onClose={() => {}} />
+      </MemoryRouter>
+    )
+
+    // Switch to Markdown tab and enter content
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const markdownField = await screen.findByLabelText('Markdown Content')
+    fireEvent.change(markdownField, { target: { value: 'Original markdown' } })
+
+    // Switch to Arguments tab to import JSON
+    fireEvent.click(screen.getByRole('tab', { name: /arguments/i }))
+
+    const jsonInput = container.querySelector('#arguments-json-file-input') as HTMLInputElement
+    const jsonContent = {
+      arguments: [
+        {
+          core: { name: 'Arg1', summary: '' },
+          zones: [],
+          dependencies: [],
+          modes: {},
+          counterarguments: [],
+          subarguments: [],
+          validation: { isValid: true, errors: [], warnings: [] },
+          pagination: { currentPage: 1, totalPages: 1 }
+        }
+      ]
+    }
+    const file = new File([JSON.stringify(jsonContent)], 'test.json', { type: 'application/json' })
+
+    const fileReaderMock = {
+      onload: null as ((this: FileReader, ev: ProgressEvent<FileReader>) => any) | null,
+      readAsText(this: any, _file: Blob) {
+        this.onload?.({ target: { result: JSON.stringify(jsonContent) } })
+      }
+    }
+    vi.spyOn(window, 'FileReader').mockImplementation(() => fileReaderMock as any)
+
+    await act(async () => {
+      fireEvent.change(jsonInput, { target: { files: [file] } })
+    })
+
+    // Return to Markdown tab and ensure content is unchanged
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const markdownFieldAfter = await screen.findByLabelText('Markdown Content')
+    expect((markdownFieldAfter as HTMLInputElement).value).toBe('Original markdown')
+    vi.restoreAllMocks()
   })
 })
 


### PR DESCRIPTION
## Summary
- avoid propagating markdownContent when importing JSON in ObjectFormModal
- ensure ObjectForm initialData effect leaves markdownContent untouched
- add unit test verifying JSON import preserves markdown text

## Testing
- `npm test` *(fails: logicRemarkPlugin avoids false positives inside longer words; ObjectForm Validation should show validation errors for empty title)*

------
https://chatgpt.com/codex/tasks/task_e_68ab532477e48328b443983b04aa3f8c