### PR TITLE
Propagate imported markdown content through ObjectForm

### DIFF
--- a/src/components/InputForm/ObjectForm.tsx
+++ b/src/components/InputForm/ObjectForm.tsx
@@ -84,6 +84,7 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
 
       let importedArgs: any[] = []
       let importedTitle: string | undefined
+      const importedMarkdown = (initialData as any).markdownContent
 
       // NOTE: Per requirement, importing JSON must NOT change markdownContent.
       // We will only map JSON into arguments and title hints.
@@ -102,28 +103,28 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
         log('mapped raw JSON arguments', { importedArgsLen: importedArgs.length })
       }
 
-      if (importedArgs.length > 0) {
-        setFormData(prev => {
-          const nextMeta = {
-            ...prev.metadata,
-            title: prev.metadata?.title || importedTitle || prev.metadata?.title,
-            created: prev.metadata?.created || new Date().toISOString(),
-            modified: new Date().toISOString(),
-            fileReferences: prev.metadata?.fileReferences || []
-          }
-          return {
-            ...prev,
-            zflnJson: {
-              ...prev.zflnJson,
-              arguments: importedArgs
-            },
-            metadata: nextMeta,
-            // Do not modify markdownContent when importing JSON
-            markdownContent: prev.markdownContent || ''
-          }
-        })
-        log('applied initialData mapping', { argsLen: importedArgs.length, title: importedTitle })
-      }
+        if (importedArgs.length > 0 || importedMarkdown !== undefined) {
+          setFormData(prev => {
+            const nextMeta = {
+              ...prev.metadata,
+              title: prev.metadata?.title || importedTitle || prev.metadata?.title,
+              created: prev.metadata?.created || new Date().toISOString(),
+              modified: new Date().toISOString(),
+              fileReferences: prev.metadata?.fileReferences || []
+            }
+            return {
+              ...prev,
+              zflnJson: {
+                ...prev.zflnJson,
+                arguments: importedArgs.length > 0 ? importedArgs : prev.zflnJson.arguments
+              },
+              metadata: nextMeta,
+              // Preserve existing markdown unless provided
+              markdownContent: importedMarkdown ?? (prev.markdownContent || '')
+            }
+          })
+          log('applied initialData mapping', { argsLen: importedArgs.length, title: importedTitle })
+        }
     }
   }, [initialData, objectId])
 

--- a/src/components/InputForm/ObjectFormModal.tsx
+++ b/src/components/InputForm/ObjectFormModal.tsx
@@ -99,6 +99,7 @@ export default function ObjectFormModal({
           
           // Create a basic ZLFN structure with the markdown content
           const markdownData = {
+            markdownContent: content,
             arguments: [{
               title: fileName,
               markdown: {


### PR DESCRIPTION
## Summary
- ensure markdown imports expose raw content to parent components
- copy imported markdownContent into ObjectForm state when present

## Testing
- `npm test` *(fails: 6 failed, missing modules and assertions)*
- `npm run lint` *(fails: 1216 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68ab53237ed483289ef06948a0ac86ac