### PR TITLE
feat: preserve markdown on imports

### DIFF
--- a/src/components/InputForm/ObjectForm.tsx
+++ b/src/components/InputForm/ObjectForm.tsx
@@ -84,9 +84,14 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
 
       let importedArgs: any[] = []
       let importedTitle: string | undefined
+      let importedMarkdown: string | undefined
 
       // NOTE: Per requirement, importing JSON must NOT change markdownContent.
-      // We will only map JSON into arguments and title hints.
+      // We will only map JSON into arguments and title hints unless markdownContent is explicitly provided.
+
+      if (typeof (initialData as any).markdownContent === 'string') {
+        importedMarkdown = (initialData as any).markdownContent
+      }
 
       if (Array.isArray(initialData)) {
         // initialData is likely SharedArgument[] from normalizeImportedJSON
@@ -102,7 +107,7 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
         log('mapped raw JSON arguments', { importedArgsLen: importedArgs.length })
       }
 
-      if (importedArgs.length > 0) {
+      if (importedArgs.length > 0 || importedMarkdown !== undefined) {
         setFormData(prev => {
           const nextMeta = {
             ...prev.metadata,
@@ -113,15 +118,15 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
           }
           return {
             ...prev,
+            ...(importedMarkdown !== undefined ? { markdownContent: importedMarkdown } : {}),
             zflnJson: {
               ...prev.zflnJson,
-              arguments: importedArgs
+              arguments: importedArgs.length > 0 ? importedArgs : prev.zflnJson?.arguments || []
             },
             metadata: nextMeta
-            // markdownContent intentionally left unchanged
           }
         })
-        log('applied initialData mapping', { argsLen: importedArgs.length, title: importedTitle })
+        log('applied initialData mapping', { argsLen: importedArgs.length, title: importedTitle, md: importedMarkdown?.length })
       }
     }
   }, [initialData, objectId])

--- a/src/components/InputForm/ObjectFormModal.tsx
+++ b/src/components/InputForm/ObjectFormModal.tsx
@@ -104,6 +104,7 @@ export default function ObjectFormModal({
           
           // Create a basic ZLFN structure with the markdown content
           const markdownData = {
+            markdownContent: content,
             arguments: [{
               title: fileName,
               markdown: {

--- a/src/tests/components/ObjectForm.test.tsx
+++ b/src/tests/components/ObjectForm.test.tsx
@@ -68,7 +68,7 @@ describe('ObjectForm', () => {
         this.onload?.({ target: { result: JSON.stringify(jsonContent) } })
       }
     }
-    vi.spyOn(window, 'FileReader').mockImplementation(() => fileReaderMock as any)
+    const frSpy = vi.spyOn(window, 'FileReader').mockImplementation(() => fileReaderMock as any)
 
     await act(async () => {
       fireEvent.change(jsonInput, { target: { files: [file] } })
@@ -78,7 +78,59 @@ describe('ObjectForm', () => {
     fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
     const markdownFieldAfter = await screen.findByLabelText('Markdown Content')
     expect((markdownFieldAfter as HTMLInputElement).value).toBe('Original markdown')
-    vi.restoreAllMocks()
+    frSpy.mockRestore()
+  })
+
+  it('loads markdown content from initialData into textarea', async () => {
+    const initialData = { markdownContent: '# Imported\n\nContent', arguments: [] }
+
+    render(
+      <MemoryRouter initialEntries={[{ pathname: '/create' }] as any}>
+        <ObjectForm onClose={() => {}} initialData={initialData} />
+      </MemoryRouter>
+    )
+
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const markdownField = await screen.findByLabelText('Markdown Content')
+    expect((markdownField as HTMLInputElement).value).toBe('# Imported\n\nContent')
+  })
+
+  it('does not overwrite markdown when reinitialized with JSON data', async () => {
+    const markdownData = { markdownContent: 'Original markdown', arguments: [] }
+    const jsonData = {
+      arguments: [
+        {
+          core: { name: 'Arg1', summary: '' },
+          zones: [],
+          dependencies: [],
+          modes: {},
+          counterarguments: [],
+          subarguments: [],
+          validation: { isValid: true, errors: [], warnings: [] },
+          pagination: { currentPage: 1, totalPages: 1 }
+        }
+      ]
+    }
+
+    const Wrapper = ({ data }: { data: any }) => (
+      <MemoryRouter initialEntries={[{ pathname: '/create' }] as any}>
+        <ObjectForm onClose={() => {}} initialData={data} />
+      </MemoryRouter>
+    )
+
+    const { rerender } = render(<Wrapper data={markdownData} />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const mdField = await screen.findByLabelText('Markdown Content')
+    expect((mdField as HTMLInputElement).value).toBe('Original markdown')
+
+    await act(async () => {
+      rerender(<Wrapper data={jsonData} />)
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const mdFieldAfter = await screen.findByLabelText('Markdown Content')
+    expect((mdFieldAfter as HTMLInputElement).value).toBe('Original markdown')
   })
 })
 


### PR DESCRIPTION
## Summary
- keep imported markdown content separate when loading JSON arguments
- load markdown text from modal imports into ObjectForm
- cover ObjectForm initializer to ensure markdown is retained

## Testing
- `npm test` *(fails: DocumentViewer/logicRemarkPlugin.test.ts and ObjectForm.validation.test.tsx)*
- `npx vitest run src/tests/components/ObjectForm.test.tsx`
- `npm run lint` *(fails: many no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5b16d67883288866d78ee6294e27