### PR TITLE
Preserve markdown during JSON imports

### DIFF
--- a/src/components/InputForm/ObjectForm.tsx
+++ b/src/components/InputForm/ObjectForm.tsx
@@ -130,7 +130,7 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
           }
           return {
             ...prev,
-            ...(importedMarkdown !== undefined ? { markdownContent: importedMarkdown } : {}),
+            markdownContent: importedMarkdown !== undefined ? importedMarkdown : prev.markdownContent,
             zflnJson: {
               ...prev.zflnJson,
               arguments: importedArgs.length > 0 ? importedArgs : prev.zflnJson?.arguments || []

--- a/src/components/InputForm/ObjectFormModal.tsx
+++ b/src/components/InputForm/ObjectFormModal.tsx
@@ -81,7 +81,9 @@ export default function ObjectFormModal({
             const { markdownContent, ...rest } = arg as any
             return rest
           })
-          setImportedData(normalized)
+          // Only populate arguments – markdown content should remain
+          // untouched so existing edits in ObjectForm are preserved
+          setImportedData({ arguments: normalized })
           setFormProgress(75)
         } catch (error) {
           console.error('Failed to import JSON:', error)

--- a/src/tests/components/ObjectForm.test.tsx
+++ b/src/tests/components/ObjectForm.test.tsx
@@ -12,6 +12,10 @@ vi.mock('../../services/apiConfig', () => ({
   apiConfig: { getConfig: () => ({ useRealBackend: false }) }
 }))
 
+vi.mock('../../context/LogicSharedContext', () => ({
+  useLogicShared: () => ({ loadMarkdownDocument: vi.fn(), setActiveSource: vi.fn() })
+}))
+
 describe('ObjectForm', () => {
   it('renders and submits new object', async () => {
     render(
@@ -131,6 +135,43 @@ describe('ObjectForm', () => {
     fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
     const mdFieldAfter = await screen.findByLabelText('Markdown Content')
     expect((mdFieldAfter as HTMLInputElement).value).toBe('Original markdown')
+  })
+
+  it('retains typed markdown when JSON arguments are provided later', async () => {
+    const jsonData = {
+      arguments: [
+        {
+          core: { name: 'Arg1', summary: '' },
+          zones: [],
+          dependencies: [],
+          modes: {},
+          counterarguments: [],
+          subarguments: [],
+          validation: { isValid: true, errors: [], warnings: [] },
+          pagination: { currentPage: 1, totalPages: 1 }
+        }
+      ]
+    }
+
+    const Wrapper = ({ data }: { data?: any }) => (
+      <MemoryRouter initialEntries={[{ pathname: '/create' }] as any}>
+        <ObjectForm onClose={() => {}} initialData={data} />
+      </MemoryRouter>
+    )
+
+    const { rerender } = render(<Wrapper />)
+
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const mdField = await screen.findByLabelText('Markdown Content')
+    fireEvent.change(mdField, { target: { value: 'Typed markdown' } })
+
+    await act(async () => {
+      rerender(<Wrapper data={jsonData} />)
+    })
+
+    fireEvent.click(screen.getByRole('tab', { name: /markdown/i }))
+    const mdFieldAfter = await screen.findByLabelText('Markdown Content')
+    expect((mdFieldAfter as HTMLInputElement).value).toBe('Typed markdown')
   })
 })
 


### PR DESCRIPTION
## Summary
- Ensure markdown imports include top-level `markdownContent`
- Only update `zflnJson.arguments` on JSON imports so markdown is preserved
- Add tests verifying JSON imports don't clobber existing markdown

## Testing
- `npx vitest run src/tests/components/ObjectForm.test.tsx`
- `npm test` *(fails: useLogicShared must be used within LogicSharedProvider, module mock errors, and other unrelated test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8dd9a4dc8328a36f5f70a14517ca