### PR TITLE
Seed sample argument and improve fallbacks

### DIFF
--- a/src/context/LogicSharedContext.tsx
+++ b/src/context/LogicSharedContext.tsx
@@ -129,41 +129,44 @@ export const LogicSharedProvider: React.FC<{ children: React.ReactNode }> = ({ c
 					} catch {}
 				}
 
-				if (fullObjects.length === 0) return
-
-				const serverArgs = fullObjects.map((obj: any) => ({
-					id: obj.id,
-					title: obj.metadata?.title || obj.title || (obj.id ? obj.id.replace(/_/g, ' ') : 'Untitled'),
-					markdown: {
-						documentId: obj.id,
-						content: obj.markdownContent || '',
-						source: obj.metadata?.isFromDatabase ? 'database' : 'mock',
-						lastModified: obj.metadata?.modified,
-						author: obj.metadata?.author
-					},
-					expressions: [],
-					metadata: {
-						created: obj.metadata?.created,
-						modified: obj.metadata?.modified,
-						author: obj.metadata?.author,
-						description: obj.metadata?.description,
-						status: obj.metadata?.status,
-						isFromDatabase: !!obj.metadata?.isFromDatabase
-					},
-					zlfnGraph: obj.zlfnJson && Array.isArray(obj.zlfnJson.nodes) && Array.isArray(obj.zlfnJson.edges)
-						? {
-							nodes: obj.zlfnJson.nodes.map((n: any) => ({
-								...n,
-								argumentId: n.argumentId || obj.id
-							})),
-							edges: obj.zlfnJson.edges || []
-						}
-						: undefined
-				}))
-				if (cancelled) return
-				setUnifiedData(prev => {
-					const map = new Map(prev.arguments.map(a => [a.id, a]))
-					for (const a of serverArgs) map.set(a.id, a)
+                                let serverArgs: any[]
+                                if (fullObjects.length === 0) {
+                                        serverArgs = [normalizeExpression('(A ∧ B) → C')]
+                                } else {
+                                        serverArgs = fullObjects.map((obj: any) => ({
+                                                id: obj.id,
+                                                title: obj.metadata?.title || obj.title || (obj.id ? obj.id.replace(/_/g, ' ') : 'Untitled'),
+                                                markdown: {
+                                                        documentId: obj.id,
+                                                        content: obj.markdownContent || '',
+                                                        source: obj.metadata?.isFromDatabase ? 'database' : 'mock',
+                                                        lastModified: obj.metadata?.modified,
+                                                        author: obj.metadata?.author
+                                                },
+                                                expressions: [],
+                                                metadata: {
+                                                        created: obj.metadata?.created,
+                                                        modified: obj.metadata?.modified,
+                                                        author: obj.metadata?.author,
+                                                        description: obj.metadata?.description,
+                                                        status: obj.metadata?.status,
+                                                        isFromDatabase: !!obj.metadata?.isFromDatabase
+                                                },
+                                                zlfnGraph: obj.zlfnJson && Array.isArray(obj.zlfnJson.nodes) && Array.isArray(obj.zlfnJson.edges)
+                                                        ? {
+                                                                nodes: obj.zlfnJson.nodes.map((n: any) => ({
+                                                                        ...n,
+                                                                        argumentId: n.argumentId || obj.id
+                                                                })),
+                                                                edges: obj.zlfnJson.edges || []
+                                                        }
+                                                        : undefined
+                                        }))
+                                }
+                                if (cancelled) return
+                                setUnifiedData(prev => {
+                                        const map = new Map(prev.arguments.map(a => [a.id, a]))
+                                        for (const a of serverArgs) map.set(a.id, a)
 					let merged = Array.from(map.values())
 					// Fallback demo argument if nothing available
 					if (merged.length === 0) {
@@ -387,10 +390,19 @@ export const LogicSharedProvider: React.FC<{ children: React.ReactNode }> = ({ c
 				(databaseObject.metadata?.title || databaseObject.title || title || documentId) : 
 				(title || documentId)
 			
-			// Use normalizeDocument to align with parseDocumentToGraph workflow
-			const normalizedArguments = await normalizeDocument(documentId, effectiveContent)
-			
-			setUnifiedData(prev => {
+                        // Use normalizeDocument to align with parseDocumentToGraph workflow
+                        let normalizedArguments = await normalizeDocument(documentId, effectiveContent)
+                        if (normalizedArguments.length === 0) {
+                                const extraction = extractArgumentsFromMarkdown(documentId, effectiveContent, effectiveTitle)
+                                normalizedArguments = extraction.arguments.length > 0 ? extraction.arguments : [{
+                                        id: documentId,
+                                        title: effectiveTitle,
+                                        markdown: { documentId, content: effectiveContent },
+                                        expressions: []
+                                }]
+                        }
+
+                        setUnifiedData(prev => {
 				// Remove existing arguments from this document
 				const filteredArguments = prev.arguments.filter(arg => 
 					!arg.markdown.documentId || arg.markdown.documentId !== documentId

--- a/src/services/zlfnObjectManager.ts
+++ b/src/services/zlfnObjectManager.ts
@@ -14,13 +14,49 @@ import type {
   ConflictResolution,
   UploadValidation
 } from '../types/zlfn'
-import { createEmptyZLFNObject } from '../types/zlfn'
+import { createEmptyZLFNObject, createEmptyZLFNStructure } from '../types/zlfn'
 import realAPI from './realAPI'
 import { apiConfig } from './apiConfig'
 
 export class ZLFNObjectManager {
   private objects: Map<string, ZLFNObject> = new Map()
   private locks: Map<string, { userId: string; expires: number }> = new Map()
+
+  constructor() {
+    const now = new Date().toISOString()
+    const markdown = '# Sample Argument\n\n1. A\n2. B\n3. Therefore C'
+    const structure = createEmptyZLFNStructure()
+    const arg = structure.arguments[0]
+    arg.core.name = 'Sample Argument'
+    arg.zones[0].nodes = [
+      { id: 'n1', name: 'A', symbolic: 'A', translation: 'A', type: 'premise', vennRelevant: false, timelineRelevant: false, facets: {} },
+      { id: 'n2', name: 'B', symbolic: 'B', translation: 'B', type: 'premise', vennRelevant: false, timelineRelevant: false, facets: {} },
+      { id: 'n3', name: 'C', symbolic: 'C', translation: 'C', type: 'conclusion', vennRelevant: false, timelineRelevant: false, facets: {} }
+    ]
+    arg.dependencies = [
+      { id: 'd1', source: 'n1', target: 'n3', rule: 'support', context: '', priority: 1 },
+      { id: 'd2', source: 'n2', target: 'n3', rule: 'support', context: '', priority: 1 }
+    ]
+    arg.modes.propositional = true
+    structure.metadata.created = now
+    structure.metadata.modified = now
+
+    const sample = createEmptyZLFNObject('sample-object-1')
+    sample.markdownContent = markdown
+    sample.zflnJson = structure
+    sample.metadata.modified = now
+    sample.metadata.title = 'Sample Argument'
+    const initialVersion: ZLFNVersion = {
+      timestamp: now,
+      markdownContent: markdown,
+      zflnJson: structure,
+      notes: sample.notes,
+      changeType: 'created',
+      changeDescription: 'Seeded sample object'
+    }
+    sample.versionHistory.push(initialVersion)
+    this.objects.set('sample-object-1', sample)
+  }
 
   // Object CRUD Operations
   async createObject(markdown?: string, initialJson?: ZLFNStructure): Promise<ZLFNObject> {


### PR DESCRIPTION
## Summary
- Ensure server arguments always include a fallback expression when none are returned
- Add placeholder generation when markdown normalization yields no arguments
- Seed `sample-object-1` with minimal markdown and ZLFN JSON at startup

## Testing
- `npm test` *(fails: Failed to resolve import "supertest" from tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8ddb5de883288f5c7e9108811146