### PR TITLE
Capture created ID and support client-supplied IDs

### DIFF
--- a/src/components/InputForm/ObjectForm.tsx
+++ b/src/components/InputForm/ObjectForm.tsx
@@ -446,9 +446,13 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
         }
 
         if (!res?.success) throw new Error(res?.error || 'Create failed')
+        const createdId = res.data?.id
+        if (createdId) {
+          setFormData(prev => ({ ...prev, id: createdId }))
+        }
         // Immediately surface the new document in the unified argument list
         try {
-          const newId = formData.id || ''
+          const newId = createdId || formData.id || ''
           const md = formData.markdownContent || ''
           const t = formData.metadata?.title
           if (newId) {
@@ -456,10 +460,11 @@ export default function ObjectForm({ objectId, onClose, initialData }: ObjectFor
             setActiveSource('document')
           }
         } catch {}
-        
+
         // Navigate to the new route if ID is set
-        if (formData.id) {
-          window.history.pushState({}, '', `/${formData.id}`)
+        const navId = createdId || formData.id
+        if (navId) {
+          window.history.pushState({}, '', `/${navId}`)
         }
       }
       

--- a/src/services/zlfnAPI.ts
+++ b/src/services/zlfnAPI.ts
@@ -34,10 +34,30 @@ class ZLFNAPIService {
     }
   }
 
-  async createObject(markdown?: string, zflnJson?: ZLFNStructure): Promise<APIResponse<ZLFNObject>> {
+  async createObject(markdown?: string, zflnJson?: ZLFNStructure): Promise<APIResponse<ZLFNObject>>
+  async createObject(id: string, markdown?: string, zflnJson?: ZLFNStructure): Promise<APIResponse<ZLFNObject>>
+  async createObject(
+    idOrMarkdown?: string,
+    markdownOrJson?: string | ZLFNStructure,
+    maybeJson?: ZLFNStructure
+  ): Promise<APIResponse<ZLFNObject>> {
     try {
-      const object = await zlfnObjectManager.createObject(markdown, zflnJson)
-      
+      let object: ZLFNObject
+      if (typeof markdownOrJson === 'string' || maybeJson !== undefined) {
+        // Signature: (id, markdown?, json?)
+        object = await zlfnObjectManager.createObject(
+          idOrMarkdown as string,
+          markdownOrJson as string | undefined,
+          maybeJson
+        )
+      } else {
+        // Signature: (markdown?, json?)
+        object = await zlfnObjectManager.createObject(
+          idOrMarkdown,
+          markdownOrJson as ZLFNStructure | undefined
+        )
+      }
+
       return this.createSuccessResponse(object)
     } catch (error) {
       return this.createErrorResponse(error instanceof Error ? error.message : 'Unknown error')
@@ -373,7 +393,11 @@ export { ZLFNAPIService }
 export const api = {
   // Object operations
   getObject: (id: string) => zlfnAPI.getObject(id),
-  createObject: (markdown?: string, zflnJson?: ZLFNStructure) => zlfnAPI.createObject(markdown, zflnJson),
+  createObject: (
+    idOrMarkdown?: string,
+    markdownOrJson?: string | ZLFNStructure,
+    json?: ZLFNStructure
+  ) => zlfnAPI.createObject(idOrMarkdown as any, markdownOrJson as any, json),
   updateObject: (id: string, updates: Partial<ZLFNObject>) => zlfnAPI.updateObject(id, updates),
   deleteObject: (id: string) => zlfnAPI.deleteObject(id),
   

--- a/src/services/zlfnObjectManager.ts
+++ b/src/services/zlfnObjectManager.ts
@@ -59,14 +59,36 @@ export class ZLFNObjectManager {
   }
 
   // Object CRUD Operations
-  async createObject(markdown?: string, initialJson?: ZLFNStructure): Promise<ZLFNObject> {
-    const id = this.generateId()
-    const object = createEmptyZLFNObject(id)
-    
+  async createObject(markdown?: string, initialJson?: ZLFNStructure): Promise<ZLFNObject>
+  async createObject(id: string, markdown?: string, initialJson?: ZLFNStructure): Promise<ZLFNObject>
+  async createObject(
+    idOrMarkdown?: string,
+    markdownOrJson?: string | ZLFNStructure,
+    maybeJson?: ZLFNStructure
+  ): Promise<ZLFNObject> {
+    // Determine arguments based on overload used
+    let id: string | undefined
+    let markdown: string | undefined
+    let initialJson: ZLFNStructure | undefined
+
+    if (typeof markdownOrJson === 'string' || maybeJson !== undefined) {
+      // Signature: (id, markdown?, json?)
+      id = idOrMarkdown
+      markdown = markdownOrJson as string | undefined
+      initialJson = maybeJson
+    } else {
+      // Signature: (markdown?, json?)
+      markdown = idOrMarkdown
+      initialJson = markdownOrJson as ZLFNStructure | undefined
+    }
+
+    const finalId = id || this.generateId()
+    const object = createEmptyZLFNObject(finalId)
+
     if (markdown) {
       object.markdownContent = this.sanitizeMarkdown(markdown)
     }
-    
+
     if (initialJson) {
       object.zflnJson = initialJson
     }
@@ -80,11 +102,11 @@ export class ZLFNObjectManager {
       changeType: 'created',
       changeDescription: 'Initial version'
     }
-    
+
     object.versionHistory.push(initialVersion)
     object.metadata.modified = new Date().toISOString()
-    
-    this.objects.set(id, object)
+
+    this.objects.set(finalId, object)
 
     // Fire-and-forget server sync
     this.syncCreate(object).catch(() => {})


### PR DESCRIPTION
## Summary
- Update ObjectForm to use server-returned object IDs and navigate accordingly
- Allow zlfnAPI and zlfnObjectManager to accept optional client-provided IDs
- Expose overloaded createObject helper in mock API interface

## Testing
- `npm test` *(fails: module mocking errors and missing providers)*

------
https://chatgpt.com/codex/tasks/task_e_68ab92a1beb88328a264850dd26bd93e